### PR TITLE
Features/xavier calendar

### DIFF
--- a/pick_up_app/templates/pick_up_app/calendar.html
+++ b/pick_up_app/templates/pick_up_app/calendar.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+
+{% load static %}
+<head>
+  <meta charset="utf-8">
+  <title> Team Calendar Page</title>
+</head>
+<body>
+{% block content %}
+    <div>
+	    <a class="btn btn-info left" href="{% url 'calendar' %}?{{ last_month }}"> Previous Month </a>
+	    <a class="btn btn-info right" href="{% url 'calendar' %}?{{ next_month }}"> Next Month </a>
+    </div>
+    {{ calendar }}
+{% endblock %}
+</body>
+</html>

--- a/pick_up_app/urls.py
+++ b/pick_up_app/urls.py
@@ -11,5 +11,6 @@ urlpatterns = [
     path('login/', views.index, name='index'),
     path('save/', views.save, name='save'),
     path('check/', views.check, name='check'),
+    path('calendar/', views.TeamCalendarView.as_view(), name='calendar'),
     path('<username>/', views.home_page, name='home_page'),
 ]

--- a/pick_up_app/utils.py
+++ b/pick_up_app/utils.py
@@ -1,0 +1,51 @@
+# cal/utils.py
+
+from datetime import datetime, timedelta
+from calendar import HTMLCalendar
+from .models import TimeSlot
+
+
+# An extension of python's HTMLCalendar with overridden methods to implement time slots
+class Calendar(HTMLCalendar):
+    def __init__(self, year=None, month=None):
+        self.year = year
+        self.month = month
+        super(Calendar, self).__init__()
+
+    # Overrides format day to show the timeslots for the day
+    def formatday(self, day, slots):
+        slots_per_day = slots.filter(slot_start__day=day)
+        formatted_day = ''
+
+        # For each Timeslot object of the day, list the game name
+        for s in slots_per_day:
+            formatted_day += f'<li> {s.game.game} </li>'
+
+        # If the day is not a valid day in the month, return an empty cell
+        if not day:
+            return '<td></td>'
+        return f"<td><span class='date'>{day}</span><ul> {formatted_day} </ul></td>"
+
+    # Overrides format week
+    def formatweek(self, week, slots):
+        formatted_week = ''
+
+        # For each tuple day, format the day number
+        for day in week:
+            formatted_week += self.formatday(day[0], slots)
+        return f'<tr> {formatted_week} </tr>'
+
+    # Overrides format month
+    def formatmonth(self):
+        # Retrieves the all timeslots for the current month and year
+        slots = TimeSlot.objects.filter(slot_start__year=self.year, slot_start__month=self.month)
+
+        # Formats the month's header using methods from HTMLCalendar
+        formatted_month = f'<table border="2" cellpadding="5" cellspacing="1" class="calendar">\n'
+        formatted_month += f'{self.formatmonthname(self.year, self.month)}\n'
+        formatted_month += f'{self.formatweekheader()}\n'
+
+        # For each week in the list of weeks in the month, format the week
+        for week in self.monthdays2calendar(self.year, self.month):
+            formatted_month += f'{self.formatweek(week, slots)}\n'
+        return formatted_month


### PR DESCRIPTION
Creates a calendar page displaying a simple calendar which displays the current month and links to future or past months. 

Implements a new file utils.py
- used to override formatmonth, formatweek, and most importantly formatday such that a cell representing each day is able to list a team's Time slots once implemented in separate story

Implements a new file calendar.html
- used to display the calendar and create hyperlinks to the next button

Updates views.py
- implements a new TeamCalendarView class which redefines get_context_data to send extra context data
- implements get_request_date to attempt to pull the date (if it exists) from the web request
- implements get_next_month() and get_last_month() to return strings representing future and previous months

Updates urls.py
- Added path for calendar page