### PR TITLE
Implements a working redirection calendar 

### DIFF
--- a/pick_up_app/forms.py
+++ b/pick_up_app/forms.py
@@ -1,8 +1,7 @@
 from django import forms
-from django.forms import ModelForm
-
-# Team Table
-from .models import User
+from django.forms import ModelForm, DateInput
+from django.utils import timezone
+from .models import User, TimeSlot
 
 # Error Handling
 from django.core.exceptions import ValidationError
@@ -67,3 +66,60 @@ class NewUserForm(ModelForm):
         # validate longitude
         if longitude < -180 or longitude > 180:
             raise ValidationError("ERROR: Longitude must be within -180 to 180")
+
+
+# Timeslot Form
+class TimeSlotForm(ModelForm):
+    class Meta:
+        model = TimeSlot
+
+        widgets = {
+            'team': forms.HiddenInput(),
+            'slot_start': DateInput(attrs={'type': 'datetime-local'}, format='%Y-%m-%dT%H:%M'),
+            'slot_end': DateInput(attrs={'type': 'datetime-local'}, format='%Y-%m-%dT%H:%M'),
+        }
+        fields = '__all__'
+
+    # Initializes the form, overriding the default input formats for dates
+    def __init__(self, *args, **kwargs):
+        super(TimeSlotForm, self).__init__(*args, **kwargs)
+        self.fields['slot_start'].input_formats = ('%Y-%m-%dT%H:%M',)
+        self.fields['slot_end'].input_formats = ('%Y-%m-%dT%H:%M',)
+
+    # Validates form input
+    def clean(self):
+        f = self.cleaned_data
+        team = f.get('team')
+        slot_start = f.get('slot_start')
+        slot_end = f.get('slot_end')
+
+        # Checks the end of a slot is before the beginning
+        if slot_start > slot_end:
+            raise ValidationError("ERROR: Start of timeslot must be before end")
+
+        # Checks the start and end of a slot are on the same day
+        if slot_start.day != slot_end.day:
+            raise ValidationError("ERROR: Start and end of timeslot must be on the same day")
+
+        # Checks only future timeslots are being scheduled
+        if slot_start < timezone.now():
+            raise ValidationError("ERROR: Only future timeslots may be scheduled")
+
+        # Checks timeslots do not overlap one another when a NEW timeslot is added
+        # Cannot check when editing timeslots or small modifications could not be made
+        if self.instance.pk is None:
+            daily_timeslots = TimeSlot.objects.filter(slot_start__day=slot_start.day,
+                                                      slot_end__day=slot_end.day,
+                                                      team_id=team.id)
+            for i in daily_timeslots:
+                check1 = slot_start.time() <= timezone.localtime(i.slot_end).time()
+                check2 = slot_end.time() >= timezone.localtime(i.slot_start).time()
+                if check1 and check2:
+                    raise ValidationError("ERROR: New timeslot overlaps existing timeslot")
+
+        # Checks the limit on the number of timeslots for a particular day has not been reached
+        num_timeslots = TimeSlot.objects.filter(slot_start__day=slot_start.day,
+                                                slot_end__day=slot_end.day,
+                                                team_id=team.id).count()
+        if num_timeslots >= 8:
+            raise ValidationError("ERROR: Maximum number of timeslots allowed on this day has been reached")

--- a/pick_up_app/models.py
+++ b/pick_up_app/models.py
@@ -29,10 +29,16 @@ class User(AbstractUser):
                 return user
         return None
 
+    def __str__(self):
+        return self.teamname
+
+
 class Games(models.Model):
     game = NameField(max_length = 30, unique=True)
     gameType = models.TextField(20)
 
+    def __str__(self):
+        return self.game
 
 
 class Emails(models.Model):

--- a/pick_up_app/static/css/stylecalendar.css
+++ b/pick_up_app/static/css/stylecalendar.css
@@ -1,0 +1,60 @@
+body {
+    background-color: #c1d9b4;
+    font-family: 'Ubuntu', sans-serif;
+}
+
+.calendar {
+  width: 98%;
+  margin: auto;
+  font-size: 15px;
+  color: #000000;
+}
+
+.calendar tr, .calendar td {
+  border: 1px solid black;
+}
+
+.calendar th {
+  padding: 10px;
+  text-align: center;
+  font-size: 20px;
+  background: #628760;
+}
+
+.calendar td {
+  width: 200px;
+  height: 150px;
+  padding: 20px 0px 0px 5px;
+  background: #FFFFFF;
+}
+
+.month {
+  font-size: 25px;
+}
+
+.date {
+  font-size: 16px;
+}
+
+ul {
+  height: 90%;
+  padding: 0px 5px 0px 20px;
+}
+
+a {
+  color: #000000;
+}
+
+.btn {
+  border-radius: 20px;
+  border: 1px solid #326b51;
+  cursor: pointer;
+  color: #354157;
+  background-color: #ffffff;
+  font-size: 21px;
+  padding: 5px 50px;
+}
+
+.clearfix {
+  margin: 15px;
+}

--- a/pick_up_app/static/css/styletimeslot.css
+++ b/pick_up_app/static/css/styletimeslot.css
@@ -1,0 +1,33 @@
+body {
+    background-color: #c1d9b4;
+    font-family: 'Ubuntu', sans-serif;
+}
+
+.form{
+    margin: auto;
+    font-size: 20px;
+}
+
+.form input,.form select {
+  border-radius: 20px;
+  border: 1px solid #17a2b8;
+  outline: none;
+  background: #FFFFFF;
+  padding: 10px;
+  width: 100%;
+  font-size: 18px;
+}
+
+.btn {
+  border-radius: 20px;
+  border: 1px solid #326b51;
+  cursor: pointer;
+  color: #354157;
+  background-color: #FFFFFF;
+  font-size: 21px;
+  padding: 5px 50px;
+}
+
+a {
+    color: #354157;
+}

--- a/pick_up_app/templates/pick_up_app/calendar.html
+++ b/pick_up_app/templates/pick_up_app/calendar.html
@@ -4,15 +4,40 @@
 {% load static %}
 <head>
   <meta charset="utf-8">
-  <title> Team Calendar Page</title>
+  <link rel="stylesheet" type="text/css" href="{% static 'css/stylecalendar.css' %}">
+  <link href="https://fonts.googleapis.com/css?family=Ubuntu" rel="stylesheet">
+  <title> {{viewing_team}} Team Calendar </title>
 </head>
+
+<div style="text-align: center">
+    <h1 style="font-size: 40px"> Team {{viewing_team}} Calendar</h1>
+</div>
+
 <body>
-{% block content %}
-    <div>
-	    <a class="btn btn-info left" href="{% url 'calendar' %}?{{ last_month }}"> Previous Month </a>
-	    <a class="btn btn-info right" href="{% url 'calendar' %}?{{ next_month }}"> Next Month </a>
+    <div class="redirect_buttons" style="text-align: center">
+        <button class="btn">
+            <a class="previous_month_btn" href="{% url 'calendar' viewing_team %}?{{ last_month }}"
+               style="text-decoration: none"> Previous Month </a>
+        </button>
+	    {% if viewing_team == current_team %}
+            <button class = "btn">
+                <a class="new_timeslot_btn" href="{% url 'timeslot_new' current_team %}"
+                   style="text-decoration: none"> Add New Time Slot </a>
+            </button>
+        {% endif %}
+        <button class = "btn">
+            <a class="next_month_btn" href="{% url 'calendar' viewing_team %}?{{ next_month }}"
+                style="text-decoration: none"> Next Month </a>
+        </button>
     </div>
-    {{ calendar }}
-{% endblock %}
+    <div class="calendar">
+        {{ calendar }}
+    </div>
+    <div class="redirect_buttons" style="text-align: center">
+        <button class="btn">
+            <a class="home_btn" href="{% url 'home_page' current_team %}"
+                   style="text-decoration: none"> Back to Home Page </a>
+        </button>
+    </div>
 </body>
 </html>

--- a/pick_up_app/templates/pick_up_app/timeslot.html
+++ b/pick_up_app/templates/pick_up_app/timeslot.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+
+{% load static %}
+<head>
+  <meta charset="utf-8">
+  <link rel="stylesheet" type="text/css" href="{% static 'css/styletimeslot.css' %}">
+  <link href="https://fonts.googleapis.com/css?family=Ubuntu" rel="stylesheet">
+  <title> Timeslot Page</title>
+</head>
+
+<div style="text-align: center">
+    <h1 style="font-size: 40px"> Team {{ current_team }} Time Slot Information </h1>
+</div>
+
+<body>
+    <form method="post">
+      {% csrf_token %}
+        <table class="form">
+            {{ timeslot_form}}
+        </table>
+        <div class="redirect_buttons" style="text-align: center">
+           <button type="submit" name="add" class="btn"> Submit </button>
+           {% if timeslot_id %}
+               <button type="submit" name="delete" value="delete" class="btn"> Delete </button>
+           {% endif %}
+        </div>
+    </form>
+    <div class="redirect_buttons" style="text-align: center">
+        <button class="btn">
+            <a class="calendar_btn" href="{% url 'calendar' current_team %}"
+               style="text-decoration: none"> Go Back Without Saving </a>
+        </button>
+    </div>
+</body>
+</html>

--- a/pick_up_app/test_form.py
+++ b/pick_up_app/test_form.py
@@ -1,0 +1,92 @@
+from django.test import TestCase
+from pick_up_app.models import *
+from pick_up_app.forms import *
+import datetime
+
+
+# Tests for submitting a new timeslot using the timeslot form
+class TimeSlotFormTests(TestCase):
+    # Creates a user and game to be used in subsequent tests
+    def create_user_and_game(self):
+        test_user = User(username="test", password="pass", teamname="test_team")
+        test_game = Games(game="newgame", gameType="testing")
+        test_user.save()
+        test_game.save()
+        return test_user, test_game
+
+    # Tests attempting to enter a timeslot where the end is on a different day than the start
+    def test_invalid_timeslot_different_days(self):
+        test_user, test_game = self.create_user_and_game()
+        cur_time = datetime.datetime.now()
+        test_form = TimeSlotForm(data={"team": test_user,
+                                       "game": test_game,
+                                       "slot_start": cur_time + datetime.timedelta(minutes=1),
+                                       "slot_end": cur_time + datetime.timedelta(days=1)})
+        self.assertFalse(test_form.is_valid())
+
+    # Tests attempting to enter a timeslot where the end is before the start
+    def test_invalid_timeslot_end_before_start(self):
+        test_user, test_game = self.create_user_and_game()
+        cur_time = datetime.datetime.now()
+        test_form = TimeSlotForm(data={"team": test_user,
+                                       "game": test_game,
+                                       "slot_start": cur_time + datetime.timedelta(minutes=30),
+                                       "slot_end": cur_time + datetime.timedelta(minutes=1)})
+        self.assertFalse(test_form.is_valid())
+
+    # Tests attempting to enter a timeslot where it is not advanced
+    def test_invalid_timeslot_not_advanced(self):
+        test_user, test_game = self.create_user_and_game()
+        cur_time = datetime.datetime.now()
+        test_form = TimeSlotForm(data={"team": test_user,
+                                       "game": test_game,
+                                       "slot_start": cur_time - datetime.timedelta(minutes=30),
+                                       "slot_end": cur_time - datetime.timedelta(minutes=20)})
+        self.assertFalse(test_form.is_valid())
+
+    # Tests attempting to enter a timeslot where it overlaps another timeslot
+    def test_invalid_timeslot_overlapping(self):
+        test_user, test_game = self.create_user_and_game()
+        cur_time = datetime.datetime.now()
+        test_form1 = TimeSlotForm(data={"team": test_user,
+                                        "game": test_game,
+                                        "slot_start": cur_time + datetime.timedelta(minutes=5),
+                                        "slot_end": cur_time + datetime.timedelta(minutes=10)})
+        self.assertTrue(test_form1.is_valid())
+        test_form1.save()
+
+        test_form2 = TimeSlotForm(data={"team": test_user,
+                                        "game": test_game,
+                                        "slot_start": cur_time + datetime.timedelta(minutes=3),
+                                        "slot_end": cur_time + datetime.timedelta(minutes=12)})
+        self.assertFalse(test_form2.is_valid())
+
+        test_form3 = TimeSlotForm(data={"team": test_user,
+                                        "game": test_game,
+                                        "slot_start": cur_time + datetime.timedelta(minutes=3),
+                                        "slot_end": cur_time + datetime.timedelta(minutes=7)})
+        self.assertFalse(test_form3.is_valid())
+
+        test_form4 = TimeSlotForm(data={"team": test_user,
+                                        "game": test_game,
+                                        "slot_start": cur_time + datetime.timedelta(minutes=7),
+                                        "slot_end": cur_time + datetime.timedelta(minutes=12)})
+        self.assertFalse(test_form4.is_valid())
+
+    # Tests attempting to enter too many timeslots on the same day
+    def test_too_many_timeslots(self):
+        test_user, test_game = self.create_user_and_game()
+        cur_time = datetime.datetime.now()
+
+        # Creates 8 timeslots on the same day
+        for i in range(1, 9):
+            test_form1 = TimeSlotForm(data={"team": test_user,
+                                            "game": test_game,
+                                            "slot_start": cur_time + datetime.timedelta(minutes=(i*2)),
+                                            "slot_end": cur_time + datetime.timedelta(minutes=((i*2)+1))})
+            test_form1.save()
+        test_form2 = TimeSlotForm(data={"team": test_user,
+                                        "game": test_game,
+                                        "slot_start": cur_time + datetime.timedelta(minutes=(9 * 2)),
+                                        "slot_end": cur_time + datetime.timedelta(minutes=((9 * 2) + 1))})
+        self.assertFalse(test_form2.is_valid())

--- a/pick_up_app/test_selenium.py
+++ b/pick_up_app/test_selenium.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from django.test import LiveServerTestCase
 from selenium import webdriver
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support.select import Select
 from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.firefox import GeckoDriverManager
 
@@ -12,6 +13,8 @@ from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 
 import os
 import time
+import datetime
+from django.utils import timezone
 
 # Create your tests here.
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
@@ -20,7 +23,7 @@ from selenium.webdriver.firefox.webdriver import WebDriver
 ################################################
 # Registration Tests
 ################################################
-from pick_up_app.models import User
+from pick_up_app.models import User, TimeSlot, Games
 from pick_up_app.forms import NewUserForm
 
 """
@@ -497,6 +500,238 @@ class RedirectLinkTests(StaticLiveServerTestCase):
         driver.quit()
 
 
+# Set of selenium tests for the Calendar Page
+class CalendarHTMLTests(StaticLiveServerTestCase):
+
+    # Tests that all elements on the calendar page are properly rendered when loaded
+    def test_calendar_rendering(self):
+        # Creates two users & respective timeslots to be tested
+        driver = webdriver.Firefox(executable_path=GeckoDriverManager().install())
+        test_team = "test_team"
+        test_team2 = "test_team2"
+        test_user = User(username="test", password="pass", teamname=test_team)
+        test_user2 = User(username="test2", password="pass2", teamname=test_team2)
+        test_game = Games(game="newgame", gameType="testing")
+        test_timeslot = TimeSlot(team=test_user,
+                                 game=test_game,
+                                 slot_start=timezone.now() + datetime.timedelta(minutes=1),
+                                 slot_end=timezone.now() + datetime.timedelta(minutes=30))
+        test_timeslot2 = TimeSlot(team=test_user2,
+                                  game=test_game,
+                                  slot_start=timezone.now() + datetime.timedelta(minutes=1),
+                                  slot_end=timezone.now() + datetime.timedelta(minutes=30))
+        test_game.save()
+        test_user.save()
+        test_user2.save()
+        test_timeslot.save()
+        test_timeslot2.save()
+
+        # Performs Log-in for the first test user
+        driver.get(self.live_server_url + "/pick_up_app/login/")
+        driver.find_element(by=By.XPATH, value='//input[@class="user"][@type="username"]').send_keys("test")
+        driver.find_element(by=By.XPATH, value='//input[@class="pass"][@type="password"]').send_keys("pass")
+        login_button = driver.find_element(by=By.CLASS_NAME, value="login")
+        login_button.click()
+        driver.implicitly_wait(0.5)
+        driver.get(self.live_server_url + "/pick_up_app/calendar/" + test_team)
+
+        # Try to find all the button elements which should be on the first test user's calendar
+        try:
+            driver.find_element(by=By.CLASS_NAME, value="previous_month_btn")
+            driver.find_element(by=By.CLASS_NAME, value="new_timeslot_btn")
+            driver.find_element(by=By.CLASS_NAME, value="next_month_btn")
+            driver.find_element(by=By.CLASS_NAME, value="home_btn")
+            print("SUCCESS, found logged-in user's redirection buttons")
+        except Exception:
+            print("FAILED, did not find logged-in user's redirection buttons")
+
+        # Try to find the first test user's calendar element
+        try:
+            driver.find_element(by=By.CLASS_NAME, value="calendar")
+            print("SUCCESS, found logged-in user's calendar")
+        except Exception:
+            print("FAILED, did not find logged-in user's calendar")
+
+        # Try to find a listed timeslot on the first test user's calendar
+        try:
+            driver.find_element(by=By.CLASS_NAME, value="listed_timeslot")
+            print("SUCCESS, found logged-in user's timeslot")
+        except Exception:
+            print("FAILED, did not find logged-in user's timeslot")
+
+        # Redirect to the other team's calendar while logged in as the first test user
+        driver.get(self.live_server_url + "/pick_up_app/calendar/" + test_team2)
+
+        # Try to find new timeslot button while viewing another team's calendar
+        try:
+            driver.find_element(by=By.CLASS_NAME, value="new_timeslot_btn")
+            print("FAILED, found new timeslot button while viewing another team's calendar")
+        except Exception:
+            print("SUCCESS, did not find new timeslot button while viewing another team's calendar")
+
+        # Try to find a listed timeslot while viewing the second test user's calendar
+        try:
+            driver.find_element(by=By.CLASS_NAME, value="listed_timeslot")
+            print("SUCCESS, found timeslot while viewing another team's calendar")
+        except Exception:
+            print("FAILED, did not find timeslot while viewing another team's calendar")
+
+        driver.quit()
+
+    # Tests the redirect links on the calendar work as intended
+    def test_calendar_redirection(self):
+        # Performs user log-in to be used by other tests
+        driver = webdriver.Firefox(executable_path=GeckoDriverManager().install())
+        test_team = "test_team"
+        test_user = User(username="test", password="pass", teamname=test_team)
+        test_game = Games(game="newgame", gameType="testing")
+        test_timeslot = TimeSlot(team=test_user,
+                                 game=test_game,
+                                 slot_start=timezone.now() + datetime.timedelta(minutes=1),
+                                 slot_end=timezone.now() + datetime.timedelta(minutes=30))
+        test_game.save()
+        test_user.save()
+        test_timeslot.save()
+
+        # Performs Log-in for the first test user
+        driver.get(self.live_server_url + "/pick_up_app/login/")
+        driver.find_element(by=By.XPATH, value='//input[@class="user"][@type="username"]').send_keys("test")
+        driver.find_element(by=By.XPATH, value='//input[@class="pass"][@type="password"]').send_keys("pass")
+        login_button = driver.find_element(by=By.CLASS_NAME, value="login")
+        login_button.click()
+        driver.implicitly_wait(0.5)
+        driver.get(self.live_server_url + "/pick_up_app/calendar/" + test_team)
+
+        # Tests redirection from the Calendar page to the Home Page using the home button
+        driver.find_element(by=By.CLASS_NAME, value="home_btn").click()
+        cur_title = driver.title
+        actual_title = "Team Home Page"
+        self.assertEqual(actual_title, cur_title)
+
+        # Tests redirection from the Calendar page to the Timeslot page using the new timeslot button
+        driver.get(self.live_server_url + "/pick_up_app/calendar/" + test_team)
+        driver.find_element(by=By.CLASS_NAME, value="new_timeslot_btn").click()
+        driver.implicitly_wait(0.5)
+        cur_title = driver.title
+        actual_title = "Timeslot Page"
+        self.assertEqual(actual_title, cur_title)
+
+        # Tests redirection from the Calendar page to a future month using the next month button
+        driver.get(self.live_server_url + "/pick_up_app/calendar/" + test_team)
+        driver.find_element(by=By.CLASS_NAME, value="next_month_btn").click()
+        cur_url = driver.current_url
+        actual_url = self.live_server_url+"/pick_up_app/calendar/"+test_team
+        actual_url += "/?month="+str(timezone.now().year)+"-"+str(timezone.now().month + 1)
+        self.assertEqual(cur_url, actual_url)
+
+        # Tests redirection from the Calendar page to a previous month using the previous month button
+        driver.find_element(by=By.CLASS_NAME, value="previous_month_btn").click()
+        cur_url = driver.current_url
+        actual_url = self.live_server_url + "/pick_up_app/calendar/" + test_team
+        actual_url += "/?month=" + str(timezone.now().year) + "-" + str(timezone.now().month)
+        self.assertEqual(cur_url, actual_url)
+
+        driver.quit()
+
+
+# Set of Selenium tests for the Timeslot Page
+class TimeslotHTMLTests(StaticLiveServerTestCase):
+    # Tests a new timeslot can be added and removed from the calendar
+    def test_timeslot_submission(self):
+        driver = webdriver.Firefox(executable_path=GeckoDriverManager().install())
+        cur_time = timezone.now().date() + datetime.timedelta(days=1)
+        test_time = str(cur_time.month)+str(cur_time.day)+str(cur_time.year)
+        test_team = "test_team"
+        test_user = User(username="test", password="pass", teamname=test_team)
+        test_game = Games(game="newgame", gameType="testing")
+        test_game.save()
+        test_user.save()
+
+        # Performs Log-in for the first test user
+        driver.get(self.live_server_url + "/pick_up_app/login/")
+        driver.find_element(by=By.XPATH, value='//input[@class="user"][@type="username"]').send_keys("test")
+        driver.find_element(by=By.XPATH, value='//input[@class="pass"][@type="password"]').send_keys("pass")
+        login_button = driver.find_element(by=By.CLASS_NAME, value="login")
+        login_button.click()
+        driver.implicitly_wait(0.5)
+        driver.get(self.live_server_url + "/pick_up_app/timeslot/new/" + test_team)
+
+        # Try to find submission location for game choice
+        try:
+            select_element = driver.find_element(by=By.ID, value="id_game")
+            select_object = Select(select_element)
+            select_object.select_by_index(1)
+            print("SUCCESS, found element id_game")
+        except Exception:
+            print("FAILED, could not find element id_game")
+
+        # Try to find submission location for start of a timeslot
+        try:
+            driver.find_element(by=By.ID, value="id_slot_start").send_keys(test_time)
+            driver.find_element(by=By.ID, value="id_slot_start").send_keys(Keys.TAB)
+            driver.find_element(by=By.ID, value="id_slot_start").send_keys("0245PM")
+            print("SUCCESS, found element id_slot_start")
+        except Exception:
+            print("FAILED, could not find element id_slot_start")
+
+        # Try to find submission location for end of a timeslot
+        try:
+            driver.find_element(by=By.ID, value="id_slot_end").send_keys(test_time)
+            driver.find_element(by=By.ID, value="id_slot_end").send_keys(Keys.TAB)
+            driver.find_element(by=By.ID, value="id_slot_end").send_keys("0345PM")
+            print("SUCCESS, found element id_slot_end")
+        except Exception:
+            print("FAILED, could not find element id_slot_end")
+
+        # Try to submit the newly created timeslot
+        try:
+            driver.find_element(by=By.NAME, value="add").click()
+            driver.implicitly_wait(0.5)
+            print("SUCCESS, submitted timeslot form")
+        except Exception:
+            print("FAILED, could not submit timeslot form")
+
+        # Tests the submission button redirects from the Timeslot Page to the Calendar Page
+        cur_title = driver.title
+        actual_title = test_team + " Team Calendar"
+        self.assertEqual(actual_title, cur_title)
+
+        # Try to delete the newly created timeslot
+        driver.find_element(by=By.CLASS_NAME, value="listed_timeslot").click()
+        try:
+            driver.find_element(by=By.NAME, value="delete").click()
+            print("SUCCESS, deleted timeslot")
+        except Exception:
+            print("FAILED, could not delete timeslot")
+
+        driver.quit()
+
+    def test_timeslot_redirection(self):
+        driver = webdriver.Firefox(executable_path=GeckoDriverManager().install())
+        cur_time = timezone.now().date() + datetime.timedelta(days=1)
+        test_time = str(cur_time.month) + str(cur_time.day) + str(cur_time.year)
+        test_team = "test_team"
+        test_user = User(username="test", password="pass", teamname=test_team)
+        test_game = Games(game="newgame", gameType="testing")
+        test_game.save()
+        test_user.save()
+
+        # Performs Log-in for the first test user
+        driver.get(self.live_server_url + "/pick_up_app/login/")
+        driver.find_element(by=By.XPATH, value='//input[@class="user"][@type="username"]').send_keys("test")
+        driver.find_element(by=By.XPATH, value='//input[@class="pass"][@type="password"]').send_keys("pass")
+        login_button = driver.find_element(by=By.CLASS_NAME, value="login")
+        login_button.click()
+        driver.implicitly_wait(0.5)
+        driver.get(self.live_server_url + "/pick_up_app/timeslot/new/" + test_team)
+
+        # Tests redirection from the Timeslot page to the Calendar using the calendar button
+        driver.find_element(by=By.CLASS_NAME, value="calendar_btn").click()
+        cur_title = driver.title
+        actual_title = test_team + " Team Calendar"
+        self.assertEqual(actual_title, cur_title)
+
+        driver.quit()
         print("######################################################################")
         print("#                                                                    #")
         print("#                                                                    #")

--- a/pick_up_app/urls.py
+++ b/pick_up_app/urls.py
@@ -12,7 +12,10 @@ urlpatterns = [
     path('save/', views.save, name='save'),
     path('check/', views.check, name='check'),
     path('teampage/<teamname>', views.team_page, name="team_page"),
-    path('calendar/', views.TeamCalendarView.as_view(), name='calendar'),
+    path('calendar/<teamname>/', views.TeamCalendarView.as_view(), name='calendar'),
+    path('timeslot/new/<teamname>', views.timeslot, name="timeslot_new"),
+    path('timeslot/edit/<teamname>/int:<timeslot_id>', views.timeslot, name="timeslot_edit"),
+    path('timeslot/delete/<teamname>/int:<timeslot_id>', views.timeslot, name="timeslot_delete"),
     path('<username>/', views.home_page, name='home_page'),
     path('team_search', views.team_search, name='team_search'),
 ]

--- a/pick_up_app/utils.py
+++ b/pick_up_app/utils.py
@@ -1,8 +1,9 @@
 # cal/utils.py
 
-from datetime import datetime, timedelta
 from calendar import HTMLCalendar
 from .models import TimeSlot
+from django.urls import reverse
+from django.utils import timezone
 
 
 # An extension of python's HTMLCalendar with overridden methods to implement time slots
@@ -13,13 +14,16 @@ class Calendar(HTMLCalendar):
         super(Calendar, self).__init__()
 
     # Overrides format day to show the timeslots for the day
-    def formatday(self, day, slots):
+    def formatday(self, day, slots, viewing_team, cur_team):
         slots_per_day = slots.filter(slot_start__day=day)
         formatted_day = ''
 
         # For each Timeslot object of the day, list the game name
         for s in slots_per_day:
-            formatted_day += f'<li> {s.game.game} </li>'
+            # Only show future timeslots on the calendar
+            if s.slot_start > timezone.now():
+                formatted_day += f'<li> {get_slot_url(s, viewing_team, cur_team)} </li>'
+            # For now, expired timeslots are just not shown, if need be in the future they can be deleted here
 
         # If the day is not a valid day in the month, return an empty cell
         if not day:
@@ -27,25 +31,39 @@ class Calendar(HTMLCalendar):
         return f"<td><span class='date'>{day}</span><ul> {formatted_day} </ul></td>"
 
     # Overrides format week
-    def formatweek(self, week, slots):
+    def formatweek(self, week, slots, viewing_team, cur_team):
         formatted_week = ''
 
         # For each tuple day, format the day number
         for day in week:
-            formatted_week += self.formatday(day[0], slots)
+            formatted_week += self.formatday(day[0], slots, viewing_team, cur_team)
         return f'<tr> {formatted_week} </tr>'
 
     # Overrides format month
-    def formatmonth(self):
+    def formatmonth(self, viewing_team, cur_team):
         # Retrieves the all timeslots for the current month and year
-        slots = TimeSlot.objects.filter(slot_start__year=self.year, slot_start__month=self.month)
+        slots = TimeSlot.objects.filter(team_id=viewing_team.id,
+                                        slot_start__year=self.year,
+                                        slot_start__month=self.month)
 
         # Formats the month's header using methods from HTMLCalendar
-        formatted_month = f'<table border="2" cellpadding="5" cellspacing="1" class="calendar">\n'
+        formatted_month = f'<table border="8" cellspacing="0" class="calendar">\n'
         formatted_month += f'{self.formatmonthname(self.year, self.month)}\n'
         formatted_month += f'{self.formatweekheader()}\n'
 
         # For each week in the list of weeks in the month, format the week
         for week in self.monthdays2calendar(self.year, self.month):
-            formatted_month += f'{self.formatweek(week, slots)}\n'
+            formatted_month += f'{self.formatweek(week, slots, viewing_team, cur_team)}\n'
+        formatted_month += f'</table>'
         return formatted_month
+
+
+# Gets a specific url to be listed on the calendar
+def get_slot_url(slot, viewing_team, cur_team):
+    # If a team is viewing their own calendar the url links to the edit timeslot page
+    if cur_team == viewing_team.teamname:
+        url = reverse('timeslot_edit', args=(cur_team, slot.id,))
+    # If a team is viewing another team's calendar, the url links to the challenge page
+    else:
+        return f'<a class="listed_timeslot" href="#" style="text-decoration: none"> {slot.game} </a>'
+    return f'<a class="listed_timeslot" href="{url}" style="text-decoration: none"> {slot.game} </a>'


### PR DESCRIPTION
- Implements a working redirection calendar with a timeslot form such that a user can register their team for timeslots which will appear on their team's calendar
- Implements authentication such that a user may only edit their own team's calendar but may still view the timeslots of another team
- Implements timeslot validation when a user attempts to add a new timeslot such that it must be set for the future, the start and end are on the same day and in that order, it does not overlap with any of the team's other timeslots, and it does not exceed the maximum number of timeslots allotted for a single day.
- Implements associated tests to ensure redirection between the calendar and timeslot page, timeslots are correctly validated, and timeslots appear on the calendar when added
- Implements basic styling for the calendar and timeslot pages