### PR TITLE
features/xavier_updated_timeslot_model

### DIFF
--- a/pick_up_app/forms.py
+++ b/pick_up_app/forms.py
@@ -74,11 +74,11 @@ class TimeSlotForm(ModelForm):
         model = TimeSlot
 
         widgets = {
-            'team': forms.HiddenInput(),
+            'host_team': forms.HiddenInput(),
             'slot_start': DateInput(attrs={'type': 'datetime-local'}, format='%Y-%m-%dT%H:%M'),
             'slot_end': DateInput(attrs={'type': 'datetime-local'}, format='%Y-%m-%dT%H:%M'),
         }
-        fields = '__all__'
+        exclude = ('opponent_team', 'host_won', 'opponent_won')
 
     # Initializes the form, overriding the default input formats for dates
     def __init__(self, *args, **kwargs):
@@ -89,7 +89,7 @@ class TimeSlotForm(ModelForm):
     # Validates form input
     def clean(self):
         f = self.cleaned_data
-        team = f.get('team')
+        host_team = f.get('host_team')
         slot_start = f.get('slot_start')
         slot_end = f.get('slot_end')
 
@@ -110,7 +110,7 @@ class TimeSlotForm(ModelForm):
         if self.instance.pk is None:
             daily_timeslots = TimeSlot.objects.filter(slot_start__day=slot_start.day,
                                                       slot_end__day=slot_end.day,
-                                                      team_id=team.id)
+                                                      host_team_id=host_team.id)
             for i in daily_timeslots:
                 check1 = slot_start.time() <= timezone.localtime(i.slot_end).time()
                 check2 = slot_end.time() >= timezone.localtime(i.slot_start).time()
@@ -120,6 +120,6 @@ class TimeSlotForm(ModelForm):
         # Checks the limit on the number of timeslots for a particular day has not been reached
         num_timeslots = TimeSlot.objects.filter(slot_start__day=slot_start.day,
                                                 slot_end__day=slot_end.day,
-                                                team_id=team.id).count()
+                                                host_team_id=host_team.id).count()
         if num_timeslots >= 8:
             raise ValidationError("ERROR: Maximum number of timeslots allowed on this day has been reached")

--- a/pick_up_app/models.py
+++ b/pick_up_app/models.py
@@ -64,41 +64,25 @@ class Emails(models.Model):
         ]
 
 
-class MMR(models.Model):
-    team = models.OneToOneField(User, on_delete=models.CASCADE)
-    MMR_rating = models.FloatField(default=0)
-
-    # Constraint to check if a team's MMR is positive
-    class Meta:
-        constraints = [
-            models.CheckConstraint(check=models.Q(MMR_rating__gte=0), name='Positive_MMR_Values')
-        ]
-
-
 class TimeSlot(models.Model):
-    team = models.ForeignKey(User, on_delete=models.CASCADE)
+    host_team = models.ForeignKey(User, on_delete=models.CASCADE, related_name='host_team')
     game = models.ForeignKey(Games, on_delete=models.CASCADE)
     slot_start = models.DateTimeField('Start date/time available')
     slot_end = models.DateTimeField('End date/time available')
-
-    # Checks whether the slot date is in the future or not
-    def is_advanced_date(self):
-        return self.slot_start > timezone.now()
+    opponent_team = models.ForeignKey(User, on_delete=models.CASCADE, null=True, related_name="opponent_team")
+    host_won = models.BooleanField(null=True)
+    opponent_won = models.BooleanField(null=True)
 
     # Checks the duration of a slot
     def slot_duration(self):
         return self.slot_end - self.slot_start
-
-    # Checks if the start of a slot is on the same day as the end of a slot
-    def is_slot_same_day(self):
-        return self.slot_start.day == self.slot_end.day
 
     class Meta:
         constraints = [
             # Constraint to check that a team picks unique slot date-times
             models.UniqueConstraint(
                 name='%(app_label)s_%(class)s_unique_team_slot',
-                fields=['team', 'slot_start', 'slot_end']),
+                fields=['host_team', 'slot_start', 'slot_end']),
             # Constraint to check that the start of a slot is before the end
             models.CheckConstraint(
                 name='%(app_label)s_%(class)s_slotstart_lte_slotend',

--- a/pick_up_app/static/css/stylecalendar.css
+++ b/pick_up_app/static/css/stylecalendar.css
@@ -3,6 +3,17 @@ body {
     font-family: 'Ubuntu', sans-serif;
 }
 
+h1{
+  margin-bottom: 0;
+  padding: 0;
+}
+
+h2{
+  margin-top: 10px;
+  padding: 0;
+  font-style: italic;
+}
+
 .calendar {
   width: 98%;
   margin: auto;
@@ -52,6 +63,7 @@ a {
   color: #354157;
   background-color: #ffffff;
   font-size: 21px;
+  font-family: 'Ubuntu', sans-serif;
   padding: 5px 50px;
 }
 

--- a/pick_up_app/templates/pick_up_app/calendar.html
+++ b/pick_up_app/templates/pick_up_app/calendar.html
@@ -10,7 +10,8 @@
 </head>
 
 <div style="text-align: center">
-    <h1 style="font-size: 40px"> Team {{viewing_team}} Calendar</h1>
+    <h1 style="font-size: 40px"> Team {{viewing_teamname}} Calendar</h1>
+    <h2 style="font-size: 32px"> Team Captain: {{viewing_team}}</h2>
 </div>
 
 <body>

--- a/pick_up_app/test_form.py
+++ b/pick_up_app/test_form.py
@@ -18,7 +18,7 @@ class TimeSlotFormTests(TestCase):
     def test_invalid_timeslot_different_days(self):
         test_user, test_game = self.create_user_and_game()
         cur_time = datetime.datetime.now()
-        test_form = TimeSlotForm(data={"team": test_user,
+        test_form = TimeSlotForm(data={"host_team": test_user,
                                        "game": test_game,
                                        "slot_start": cur_time + datetime.timedelta(minutes=1),
                                        "slot_end": cur_time + datetime.timedelta(days=1)})
@@ -28,7 +28,7 @@ class TimeSlotFormTests(TestCase):
     def test_invalid_timeslot_end_before_start(self):
         test_user, test_game = self.create_user_and_game()
         cur_time = datetime.datetime.now()
-        test_form = TimeSlotForm(data={"team": test_user,
+        test_form = TimeSlotForm(data={"host_team": test_user,
                                        "game": test_game,
                                        "slot_start": cur_time + datetime.timedelta(minutes=30),
                                        "slot_end": cur_time + datetime.timedelta(minutes=1)})
@@ -38,7 +38,7 @@ class TimeSlotFormTests(TestCase):
     def test_invalid_timeslot_not_advanced(self):
         test_user, test_game = self.create_user_and_game()
         cur_time = datetime.datetime.now()
-        test_form = TimeSlotForm(data={"team": test_user,
+        test_form = TimeSlotForm(data={"host_team": test_user,
                                        "game": test_game,
                                        "slot_start": cur_time - datetime.timedelta(minutes=30),
                                        "slot_end": cur_time - datetime.timedelta(minutes=20)})
@@ -48,26 +48,26 @@ class TimeSlotFormTests(TestCase):
     def test_invalid_timeslot_overlapping(self):
         test_user, test_game = self.create_user_and_game()
         cur_time = datetime.datetime.now()
-        test_form1 = TimeSlotForm(data={"team": test_user,
+        test_form1 = TimeSlotForm(data={"host_team": test_user,
                                         "game": test_game,
                                         "slot_start": cur_time + datetime.timedelta(minutes=5),
                                         "slot_end": cur_time + datetime.timedelta(minutes=10)})
         self.assertTrue(test_form1.is_valid())
         test_form1.save()
 
-        test_form2 = TimeSlotForm(data={"team": test_user,
+        test_form2 = TimeSlotForm(data={"host_team": test_user,
                                         "game": test_game,
                                         "slot_start": cur_time + datetime.timedelta(minutes=3),
                                         "slot_end": cur_time + datetime.timedelta(minutes=12)})
         self.assertFalse(test_form2.is_valid())
 
-        test_form3 = TimeSlotForm(data={"team": test_user,
+        test_form3 = TimeSlotForm(data={"host_team": test_user,
                                         "game": test_game,
                                         "slot_start": cur_time + datetime.timedelta(minutes=3),
                                         "slot_end": cur_time + datetime.timedelta(minutes=7)})
         self.assertFalse(test_form3.is_valid())
 
-        test_form4 = TimeSlotForm(data={"team": test_user,
+        test_form4 = TimeSlotForm(data={"host_team": test_user,
                                         "game": test_game,
                                         "slot_start": cur_time + datetime.timedelta(minutes=7),
                                         "slot_end": cur_time + datetime.timedelta(minutes=12)})
@@ -80,12 +80,12 @@ class TimeSlotFormTests(TestCase):
 
         # Creates 8 timeslots on the same day
         for i in range(1, 9):
-            test_form1 = TimeSlotForm(data={"team": test_user,
+            test_form1 = TimeSlotForm(data={"host_team": test_user,
                                             "game": test_game,
                                             "slot_start": cur_time + datetime.timedelta(minutes=(i*2)),
                                             "slot_end": cur_time + datetime.timedelta(minutes=((i*2)+1))})
             test_form1.save()
-        test_form2 = TimeSlotForm(data={"team": test_user,
+        test_form2 = TimeSlotForm(data={"host_team": test_user,
                                         "game": test_game,
                                         "slot_start": cur_time + datetime.timedelta(minutes=(9 * 2)),
                                         "slot_end": cur_time + datetime.timedelta(minutes=((9 * 2) + 1))})

--- a/pick_up_app/test_selenium.py
+++ b/pick_up_app/test_selenium.py
@@ -654,11 +654,11 @@ class CalendarHTMLTests(StaticLiveServerTestCase):
         test_game = Games(game="newgame", gameType="testing")
         test_game.save()
 
-        test_timeslot = TimeSlot(team=test_user,
+        test_timeslot = TimeSlot(host_team=test_user,
                                  game=test_game,
                                  slot_start=timezone.now() + datetime.timedelta(minutes=1),
                                  slot_end=timezone.now() + datetime.timedelta(minutes=30))
-        test_timeslot2 = TimeSlot(team=test_user2,
+        test_timeslot2 = TimeSlot(host_team=test_user2,
                                   game=test_game,
                                   slot_start=timezone.now() + datetime.timedelta(minutes=1),
                                   slot_end=timezone.now() + datetime.timedelta(minutes=30))
@@ -735,7 +735,7 @@ class CalendarHTMLTests(StaticLiveServerTestCase):
         test_game = Games(game="newgame", gameType="testing")
         test_game.save()
 
-        test_timeslot = TimeSlot(team=test_user,
+        test_timeslot = TimeSlot(host_team=test_user,
                                  game=test_game,
                                  slot_start=timezone.now() + datetime.timedelta(minutes=1),
                                  slot_end=timezone.now() + datetime.timedelta(minutes=30))
@@ -793,7 +793,7 @@ class TimeslotHTMLTests(StaticLiveServerTestCase):
 
         driver = webdriver.Firefox(executable_path=GeckoDriverManager().install())
         cur_time = timezone.now().date() + datetime.timedelta(days=1)
-        test_time = str(cur_time.month)+str(cur_time.day)+str(cur_time.year)
+        test_time = str(cur_time.month)+str(cur_time.day)+str(cur_time.year)+""
         test_team = "test"
         test_user = User(username="test", password="pass")
         test_game = Games(game="newgame", gameType="testing")
@@ -866,8 +866,6 @@ class TimeslotHTMLTests(StaticLiveServerTestCase):
         print("######################################################################")
 
         driver = webdriver.Firefox(executable_path=GeckoDriverManager().install())
-        cur_time = timezone.now().date() + datetime.timedelta(days=1)
-        test_time = str(cur_time.month) + str(cur_time.day) + str(cur_time.year)
         test_team = "test"
         test_user = User(username="test", password="pass")
         test_game = Games(game="newgame", gameType="testing")

--- a/pick_up_app/tests_model.py
+++ b/pick_up_app/tests_model.py
@@ -68,40 +68,26 @@ class EmailsModelTests(TestCase):
             captain_email2.save()
 
 
-
-
-
 # Creates a temporary timeslot with an input time for testing
 def create_timeslot(start_time, end_time):
     temp_team = User.objects.create(username='test_team')
     temp_game = Games.objects.create(game='test_game', gameType='Test')
-    return TimeSlot(team=temp_team, game=temp_game, slot_start=start_time, slot_end=end_time)
+    return TimeSlot(host_team=temp_team, game=temp_game, slot_start=start_time, slot_end=end_time)
 
 
 class TimeSlotModelTests(TestCase):
 
-    # Tests a timeslot object can be created and retrieved
+    # Tests a timeslot object can be created, has the correct null values, and is retrieved
     def test_create_timeslot(self):
         start_time = timezone.now() - datetime.timedelta(minutes=1)
         end_time = start_time + datetime.timedelta(hours=1)
         temp_timeslot = create_timeslot(start_time, end_time)
         temp_timeslot.save()
-        test_timeslot = TimeSlot.objects.filter(id=temp_timeslot.id)
+        test_timeslot = TimeSlot.objects.get(id=temp_timeslot.id)
         self.assertNotEqual(test_timeslot, None)
-
-    # Tests an exception is raised if an old timeslot is entered
-    def test_old_timeslot(self):
-        start_time = timezone.now() - datetime.timedelta(minutes=1)
-        end_time = start_time + datetime.timedelta(hours=1)
-        temp_timeslot = create_timeslot(start_time, end_time)
-        self.assertIs(temp_timeslot.is_advanced_date(), False)
-
-    # Tests an advanced timeslot can be entered
-    def test_future_timeslot(self):
-        start_time = timezone.now() + datetime.timedelta(minutes=1)
-        end_time = start_time + datetime.timedelta(hours=1)
-        temp_timeslot = create_timeslot(start_time, end_time)
-        self.assertIs(temp_timeslot.is_advanced_date(), True)
+        self.assertEqual(test_timeslot.opponent_team, None)
+        self.assertEqual(test_timeslot.host_won, None)
+        self.assertEqual(test_timeslot.opponent_won, None)
 
     # Tests an exception is raised if the end of a slot is before the start
     def test_invalid_timeslot(self):
@@ -111,13 +97,6 @@ class TimeSlotModelTests(TestCase):
         with self.assertRaises(Exception):
             temp_timeslot.save()
 
-    # Tests an exception is raised if the start and end of a slot are not on the same day
-    def test_invalid_timeslot2(self):
-        start_time = timezone.now() + datetime.timedelta(minutes=1)
-        end_time = start_time + datetime.timedelta(days=1)
-        temp_timeslot = create_timeslot(start_time, end_time)
-        self.assertIs(temp_timeslot.is_slot_same_day(), False)
-
     # Tests an exception is raised if a duplicate timeslot is entered
     def test_duplicate_timeslot(self):
         start_time = timezone.now() + datetime.timedelta(minutes=1)
@@ -125,7 +104,7 @@ class TimeSlotModelTests(TestCase):
         temp_timeslot1 = create_timeslot(start_time, end_time)
         temp_timeslot1.save()
         temp_game = Games.objects.create(game='test_game2', gameType='Test')
-        temp_timeslot2 = TimeSlot(team=temp_timeslot1.team, game=temp_game,
+        temp_timeslot2 = TimeSlot(host_team=temp_timeslot1.host_team, game=temp_game,
                                   slot_start=start_time, slot_end=end_time)
         with self.assertRaises(Exception):
             temp_timeslot2.save()

--- a/pick_up_app/urls.py
+++ b/pick_up_app/urls.py
@@ -15,7 +15,6 @@ urlpatterns = [
     path('calendar/<username>/', views.TeamCalendarView.as_view(), name='calendar'),
     path('timeslot/new/<username>', views.timeslot, name="timeslot_new"),
     path('timeslot/edit/<username>/int:<timeslot_id>', views.timeslot, name="timeslot_edit"),
-    path('timeslot/delete/<username>/int:<timeslot_id>', views.timeslot, name="timeslot_delete"),
     path('team_search', views.team_search, name='team_search'),
     path('new_game/', views.new_game, name='new_game'),
     path('save_game/', views.save_game, name='save_game'),

--- a/pick_up_app/utils.py
+++ b/pick_up_app/utils.py
@@ -42,7 +42,7 @@ class Calendar(HTMLCalendar):
     # Overrides format month
     def formatmonth(self, viewing_team, cur_team):
         # Retrieves the all timeslots for the current month and year
-        slots = TimeSlot.objects.filter(team_id=viewing_team.id,
+        slots = TimeSlot.objects.filter(host_team_id=viewing_team.id,
                                         slot_start__year=self.year,
                                         slot_start__month=self.month)
 

--- a/pick_up_app/views.py
+++ b/pick_up_app/views.py
@@ -162,7 +162,10 @@ class TeamCalendarView(generic.ListView):
     # Ensures only logged-in users can view calendars
     def dispatch(self, request, *args, **kwargs):
         if self.request.user.is_authenticated:
-            return super(TeamCalendarView, self).dispatch(request, *args, **kwargs)
+            try:
+                return super(TeamCalendarView, self).dispatch(request, *args, **kwargs)
+            except User.DoesNotExist:
+                return HttpResponse("The calendar you're looking for does not exist")
         else:
             return HttpResponse("Only logged in users may view another team's calendar")
 
@@ -184,6 +187,7 @@ class TeamCalendarView(generic.ListView):
 
         # Call the formatmonth method, which returns our calendar as a table
         formatted_calendar = new_calendar.formatmonth(viewing_team, cur_team)
+        context['viewing_teamname'] = viewing_team.teamname
         context['viewing_team'] = viewing_team.username
         context['current_team'] = cur_team
         context['calendar'] = mark_safe(formatted_calendar)
@@ -227,7 +231,7 @@ def timeslot(request, username, timeslot_id=None):
             if timeslot_id:
                 instance = get_object_or_404(TimeSlot, pk=timeslot_id)
             else:
-                instance = TimeSlot(team=cur_team)
+                instance = TimeSlot(host_team=cur_team)
 
             timeslot_form = TimeSlotForm(request.POST or None, instance=instance)
 


### PR DESCRIPTION
foreign key to opponent team, along with boolean fields for whether the host or opponent won added
team column of timeslot renamed host_team across multiple files
added associated tests checking that when a timeslot is created these new columns are null by default
removed redundant functions in timeslot model which are done when the form is cleaned
removed redundant MMR model
removed redundant timeslot delete URL
modified calendar html and css to include both username and teamname on a team's calendar
modified calendar view such that a user receives an HttpResponse if they try to access a calendar which does not exist