### PR TITLE
features/xavier_timeslot_redirection

### DIFF
--- a/pick_up_app/utils.py
+++ b/pick_up_app/utils.py
@@ -4,6 +4,7 @@ from calendar import HTMLCalendar
 from .models import TimeSlot
 from django.urls import reverse
 from django.utils import timezone
+import datetime
 
 
 # An extension of python's HTMLCalendar with overridden methods to implement time slots
@@ -20,10 +21,11 @@ class Calendar(HTMLCalendar):
 
         # For each Timeslot object of the day, list the game name
         for s in slots_per_day:
-            # Only show future timeslots on the calendar
-            if s.slot_start > timezone.now():
+            # If the start of a timeslot is expired and no challenge has been made, delete it
+            if (s.slot_start < timezone.now()) and (not s.opponent_team):
+                s.delete()
+            else:
                 formatted_day += f'<li> {get_slot_url(s, viewing_team, cur_team)} </li>'
-            # For now, expired timeslots are just not shown, if need be in the future they can be deleted here
 
         # If the day is not a valid day in the month, return an empty cell
         if not day:
@@ -60,10 +62,22 @@ class Calendar(HTMLCalendar):
 
 # Gets a specific url to be listed on the calendar
 def get_slot_url(slot, viewing_team, cur_team):
-    # If a team is viewing their own calendar the url links to the edit timeslot page
-    if cur_team == viewing_team.username:
-        url = reverse('timeslot_edit', args=(cur_team, slot.id,))
-    # If a team is viewing another team's calendar, the url links to the challenge page
+
+    # Creates a URL to the past match results html page if the game is over
+    if (slot.host_won is not None) and (slot.opponent_won is not None):
+        url = reverse('past_game', args=(slot.id, slot.game_id))
+
+    # Creates a URL to the "who won" html page if an opponent has made a challenge
+    elif slot.opponent_team and (cur_team.id == slot.opponent_team_id or cur_team.id == slot.host_team_id):
+        url = reverse('submit_results', args=(cur_team, slot.id))
+
+    # Creates a URL to the edit timeslot html page if a team is viewing their own calendar
+    elif cur_team.username == viewing_team.username:
+        url = reverse('timeslot_edit', args=(cur_team, slot.id))
+
+    # Creates a URL to the booking html page if a team is viewing another team's calendar
+    elif cur_team.username != viewing_team.username:
+        url = reverse('booking', args=(cur_team, slot.id))
     else:
-        return f'<a class="listed_timeslot" href="#" style="text-decoration: none"> {slot.game} </a>'
+        url = ""
     return f'<a class="listed_timeslot" href="{url}" style="text-decoration: none"> {slot.game} </a>'

--- a/pick_up_app/views.py
+++ b/pick_up_app/views.py
@@ -186,13 +186,13 @@ class TeamCalendarView(generic.ListView):
 
         # Gets the team currently making the request and the team of the calendar being viewed
         viewing_team = User.objects.get(username=self.kwargs['username'])
-        cur_team = self.request.user.username
+        cur_team = self.request.user
 
         # Call the formatmonth method, which returns our calendar as a table
         formatted_calendar = new_calendar.formatmonth(viewing_team, cur_team)
         context['viewing_teamname'] = viewing_team.teamname
         context['viewing_team'] = viewing_team.username
-        context['current_team'] = cur_team
+        context['current_team'] = cur_team.username
         context['calendar'] = mark_safe(formatted_calendar)
         context['next_month'] = get_next_month(current_month)
         context['last_month'] = get_last_month(current_month)


### PR DESCRIPTION
Creates a new system of redirection for the calendar and associated selenium tests to ensure it works.
- If a team is viewing another team's calendar and clicks on a timeslot, it redirects them to the challenge page
- If a team is viewing their own calendar and has not been challenged, it still redirects to the edit timeslot page
- If a team is viewing their own calendar and a challenge has been made, it redirects to the submit match results (SMR) page
- If a team is viewing another team's calendar and clicks on a timeslot they have challenged, it redirects to the SMR page
- If a team is viewing another team's calendar and clicks on a timeslot they have not challenged, no redirection is done
- If a timeslot has both a winning and loosing team associated, it redirects to the past match results page, regardless of viewer
- Deletes a timeslot if the starting time has passed and no challenge was made